### PR TITLE
show institution instead of title on main people page

### DIFF
--- a/content/people/index.md
+++ b/content/people/index.md
@@ -12,7 +12,8 @@ sections:
       - Members
   design:
     show_interests: false
-    show_role: true
+    show_role: false
+    show_organizations: true
     show_social: true
 title: People
 type: landing


### PR DESCRIPTION
What would you think about showing our institutions instead of our titles on the main people page?